### PR TITLE
Update README note on JSON-only responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,8 @@ test.describe('User Page', () => {
 
 Customize your plugin by passing an options object:
 
+**Note:** This plugin currently records and replays only JSON responses. Requests returning non-JSON content will pass through without being stored.
+
 ```typescript
 const apiMock = new ApiMockPlugin(page, {
   urlMatch: '**/api/**',


### PR DESCRIPTION
## Summary
- document that this plugin only records JSON responses
- note that non-JSON responses are not stored

## Testing
- `bun x biome check src`

------
https://chatgpt.com/codex/tasks/task_e_687d429c66988324b14383107d31d9b2