### PR TITLE
Add unit tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "build": "bun x tsc && bun build --entrypoints ./src/index.ts --outdir ./dist --target node --minify",
     "prepublish": "bun run check && bun run build",
     "publish": "npm publish --access public",
-		"postinstall": "npx playwright install chromium",
+                "postinstall": "npx playwright install chromium",
+    "test": "bun test unit-test",
     "demo:test": "playwright test -c test/playwright.config.ts"
   },
   "repository": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,5 +24,5 @@
 		"noPropertyAccessFromIndexSignature": true
 	},
 	"include": ["src/*.ts"],
-	"exclude": ["node_modules", "dist", "tests"]
+        "exclude": ["node_modules", "dist", "unit-test"]
 }

--- a/unit-test/plugin.test.ts
+++ b/unit-test/plugin.test.ts
@@ -1,0 +1,90 @@
+import { ApiMockPlugin } from '../src/index';
+import { test, expect } from 'bun:test';
+
+class MockRoute {
+  fulfilledWith?: any;
+  continued = false;
+  fetchCalled = false;
+
+  constructor(private url: string, private fetchResponse: any) {}
+
+  request() {
+    return { url: () => this.url } as any;
+  }
+
+  async fetch() {
+    this.fetchCalled = true;
+    return this.fetchResponse;
+  }
+
+  async fulfill(opts: any) {
+    this.fulfilledWith = opts;
+  }
+
+  async continue() {
+    this.continued = true;
+  }
+}
+
+class MockPage {
+  handler?: (route: MockRoute) => Promise<void>;
+
+  async route(_match: any, cb: any) {
+    this.handler = cb;
+  }
+
+  async trigger(route: MockRoute) {
+    if (this.handler) {
+      await this.handler(route as any);
+    }
+  }
+}
+
+test('uses stored snapshot when available', async () => {
+  const page = new MockPage();
+  const plugin = new ApiMockPlugin(page as any, {
+    apiSnapshotsPath: 'file',
+    urlMatch: '**/*',
+    logLevel: 'silent',
+  });
+
+  const snapshot = { status: 200, headers: { a: 'b' }, body: { ok: true } };
+  // @ts-ignore override private field
+  plugin.store = {
+    getStoredSnapshot: () => snapshot,
+    storeResponse: async () => {},
+  } as any;
+
+  await plugin.record();
+  const mockResp = { json: async () => ({}), status: () => 200, headers: () => ({}) };
+  const route = new MockRoute('http://example.com', mockResp);
+  await page.trigger(route);
+  expect(route.fulfilledWith?.status).toBe(200);
+  expect(route.continued).toBe(false);
+});
+
+test('records new responses when not stored', async () => {
+  const page = new MockPage();
+  const plugin = new ApiMockPlugin(page as any, {
+    apiSnapshotsPath: 'file',
+    urlMatch: '**/*',
+    logLevel: 'silent',
+  });
+
+  let storedKey: string | undefined;
+  // @ts-ignore override private field
+  plugin.store = {
+    getStoredSnapshot: () => undefined,
+    storeResponse: async (key: string) => {
+      storedKey = key;
+    },
+  } as any;
+
+  await plugin.record();
+  const response = { json: async () => ({ a: 1 }), status: () => 201, headers: () => ({}) };
+  const route = new MockRoute('http://api', response);
+  await page.trigger(route);
+  expect(route.fetchCalled).toBe(true);
+  expect(route.continued).toBe(true);
+  expect(storedKey).toBe('http://api');
+});

--- a/unit-test/store.test.ts
+++ b/unit-test/store.test.ts
@@ -1,0 +1,47 @@
+import { SnapshotsStore } from '../src/store';
+import { test, expect } from 'bun:test';
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+function createTempDir() {
+  return mkdtempSync(join(tmpdir(), 'store-'));
+}
+
+test('stores responses on disk', async () => {
+  const dir = createTempDir();
+  const file = join(dir, 'snap.json');
+  const store = new SnapshotsStore({ apiSnapshotsPath: file });
+
+  const response = {
+    async json() { return { ok: true }; },
+    status() { return 201; },
+    headers() { return { 'content-type': 'application/json' }; },
+  } as any;
+
+  await store.storeResponse('key', response);
+  const saved = JSON.parse(readFileSync(file, 'utf-8'));
+  expect(saved.key.status).toBe(201);
+  expect(saved.key.body.ok).toBe(true);
+  rmSync(dir, { recursive: true, force: true });
+});
+
+test('applies header filter', async () => {
+  const dir = createTempDir();
+  const file = join(dir, 'snap.json');
+  const store = new SnapshotsStore({
+    apiSnapshotsPath: file,
+    getStoredHeaders: (h) => ({ 'content-type': h['content-type'] }),
+  });
+
+  const response = {
+    async json() { return { a: 1 }; },
+    status() { return 200; },
+    headers() { return { 'content-type': 'application/json', other: 'x' }; },
+  } as any;
+
+  await store.storeResponse('url', response);
+  const snap = store.getStoredSnapshot('url');
+  expect(snap?.headers).toStrictEqual({ 'content-type': 'application/json' });
+  rmSync(dir, { recursive: true, force: true });
+});

--- a/unit-test/utils.test.ts
+++ b/unit-test/utils.test.ts
@@ -1,0 +1,13 @@
+import { ensureError } from '../src/utils';
+import { test, expect } from 'bun:test';
+
+test('returns the same error instance', () => {
+  const err = new Error('oops');
+  expect(ensureError(err)).toBe(err);
+});
+
+test('wraps non-error values', () => {
+  const result = ensureError('bad');
+  expect(result).toBeInstanceOf(Error);
+  expect(result.message).toBe('bad');
+});


### PR DESCRIPTION
## Summary
- add Bun-based unit tests for the core source files
- add npm test script that executes the Bun tests
- rename the unit tests directory from `tests` to `unit-test`

## Testing
- `npm test --silent`
- ❌ `bun install` *(fails: Download failed due to blocked domain)*

------
https://chatgpt.com/codex/tasks/task_e_687d4f8780d88324af9eb427f2a97429