### PR TITLE
Add configurable mock mode to plugin and demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ export const test = base.extend({
       urlMatch: '**/api/**',
       apiSnapshotsPath: '__snapshots__/api.json',
       logLevel: 'info',
+      mock: true,
     });
     await apiMock.record();
     await use(page);
@@ -79,6 +80,7 @@ test.describe('User Page', () => {
     await apiMock.record({
       urlMatch: '**/api/user/**',
       apiSnapshotsPath: '__snapshots__/userApi.json',
+      mock: true,
     });
   });
 
@@ -101,6 +103,7 @@ const apiMock = new ApiMockPlugin(page, {
   urlMatch: '**/api/**',
   apiSnapshotsPath: '__snapshots__/api.json',
   logLevel: 'info',
+  mock: true,
   getStoredHeaders: (headers) => {
     // optionally filter or modify headers before storing
     return { 'content-type': headers['content-type'] };
@@ -116,6 +119,7 @@ const apiMock = new ApiMockPlugin(page, {
 | `apiSnapshotsPath` | `string`                             | `api_snapshots.json` | Path to store/load snapshot files                |
 | `logLevel`         | `'silent' \| 'error' \| 'info'`      | `'info'`             | Level of logging detail                          |
 | `getStoredHeaders` | `(headers) => headers \| undefined`  | `undefined`          | Function to modify or filter headers before saving|
+| `mock`             | `boolean`                            | `true`               | Use stored snapshots instead of real responses |
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "prepublish": "bun run check && bun run build",
     "publish": "npm publish --access public",
 		"postinstall": "npx playwright install chromium",
+		"demo:start": "bun run test/server.js",
     "demo:test": "playwright test -c test/playwright.config.ts"
   },
   "repository": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,9 +4,10 @@ import type { PluginConfig } from './types';
 import { ensureError } from './utils';
 
 const DEFAULT_CONFIG: PluginConfig = {
-	urlMatch: '**/*',
-	apiSnapshotsPath: 'api_snapshots.json',
-	logLevel: 'info',
+        urlMatch: '**/*',
+        apiSnapshotsPath: 'api_snapshots.json',
+        logLevel: 'info',
+       mock: true,
 };
 
 class Plugin {
@@ -38,20 +39,20 @@ class Plugin {
 			return await customPlugin.record();
 		}
 
-		await this.page.route(this.config.urlMatch, async (route) => {
-			const request = route.request();
-			const url = request.url();
+               await this.page.route(this.config.urlMatch, async (route) => {
+                       const request = route.request();
+                       const url = request.url();
 
-			const storedSnapshot = this.store.getStoredSnapshot(url);
-			if (storedSnapshot) {
-				this.log(`[Mocked] ${url}`);
-				return await route.fulfill({
-					// Content-type?
-					status: storedSnapshot.status,
-					headers: storedSnapshot.headers,
-					body: JSON.stringify(storedSnapshot.body),
-				});
-			}
+                       const storedSnapshot = this.config.mock ? this.store.getStoredSnapshot(url) : undefined;
+                       if (storedSnapshot) {
+                               this.log(`[Mocked] ${url}`);
+                               return await route.fulfill({
+                                       // Content-type?
+                                       status: storedSnapshot.status,
+                                       headers: storedSnapshot.headers,
+                                       body: JSON.stringify(storedSnapshot.body),
+                               });
+                       }
 
 			// Fetch real response and store it
 			try {

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,6 +15,12 @@ export interface StoreConfig {
 }
 
 export interface PluginConfig extends StoreConfig {
-	urlMatch: string | RegExp;
-	logLevel: LogLevel;
+        urlMatch: string | RegExp;
+        logLevel: LogLevel;
+       /**
+        * When true, stored snapshots will be used to fulfill requests.
+        * When false, responses will always be fetched from the server
+        * and stored for future use.
+        */
+       mock: boolean;
 }

--- a/test/demo/demo.spec.ts
+++ b/test/demo/demo.spec.ts
@@ -1,20 +1,5 @@
 import { expect } from '@playwright/test';
 import { test } from '../fixtures.js';
-import { startServer } from '../server.js';
-import type { Server } from 'node:http';
-
-let server: Server | null = null;
-
-test.beforeEach(async () => {
-  server = await startServer();
-});
-
-test.afterEach(async () => {
-  if (server) {
-    await new Promise((res) => server?.close(res));
-    server = null;
-  }
-});
 
 test('fetch data with mocked response', async ({ page, apiMock }) => {
   await apiMock.record();

--- a/test/demo/demo.spec.ts
+++ b/test/demo/demo.spec.ts
@@ -5,22 +5,29 @@ import type { Server } from 'node:http';
 
 let server: Server | null = null;
 
-// This test demonstrates using ApiMockPlugin with the running server
-test('fetch data from example API', async ({ page }) => {
-  // Start server if not already running
-  if (!server) {
-    server = await startServer();
-  }
+test.beforeEach(async () => {
+  server = await startServer();
+});
 
-  try {
-    await page.goto('/');
-    await expect(page.locator('#output')).toHaveText('{"id":1,"name":"John Doe"}');
-  } finally {
-    // Clean up server after test
-    const currentServer = server;
-    if (currentServer) {
-      await new Promise((res) => currentServer.close(res));
-      server = null;
-    }
+test.afterEach(async () => {
+  if (server) {
+    await new Promise((res) => server?.close(res));
+    server = null;
   }
+});
+
+test('fetch data with mocked response', async ({ page, apiMock }) => {
+  await apiMock.record();
+  await page.goto('/');
+  await expect(page.locator('#output')).toHaveText(
+    '{"id":1,"name":"John Doe","email":"john@example.com","role":"admin"}',
+  );
+});
+
+test('fetch data without mocking', async ({ page, apiMock }) => {
+  await apiMock.record({ mock: false });
+  await page.goto('/');
+  await expect(page.locator('#output')).toHaveText(
+    '{"id":1,"name":"John Doe","email":"john@example.com","role":"admin"}',
+  );
 });

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -1,14 +1,13 @@
 import { test as base } from '@playwright/test';
 import { ApiMockPlugin } from '../dist/index.js';
 
-export const test = base.extend({
-  page: async ({ page }, use) => {
-    const apiMock = new ApiMockPlugin(page, {
+export const test = base.extend<{ apiMock: ApiMockPlugin }>({
+  apiMock: async ({ page }, use) => {
+    const plugin = new ApiMockPlugin(page, {
       urlMatch: '**/api/**',
       apiSnapshotsPath: '__snapshots__/api.json',
       logLevel: 'info',
     });
-    await apiMock.record();
-    await use(page);
+    await use(plugin);
   },
 });

--- a/test/server.js
+++ b/test/server.js
@@ -5,7 +5,12 @@ export async function startServer(port = 3000) {
   const app = express();
 
   app.get('/api/user', (_req, res) => {
-    res.json({ id: 1, name: 'John Doe' });
+    res.json({
+      id: 1,
+      name: 'John Doe',
+      email: 'john@example.com',
+      role: 'admin',
+    });
   });
 
   app.get('/', (_req, res) => {


### PR DESCRIPTION
## Summary
- introduce `mock` option to control using stored API snapshots
- update README docs for new flag
- update demo server with more detailed data
- adjust Playwright demo tests to show mocked vs real flows

## Testing
- `npm run lint`
- `npm run demo:test` *(fails: browser executable missing)*

------
https://chatgpt.com/codex/tasks/task_e_687d503a275c8324804fd323b102a481